### PR TITLE
Document the value field in work_validate response

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ cd target/release
 
     ```json
     {
-        "valid": "1"
+        "valid": "1",
+        "value": "ffffffd21c3933f4"
     }
 
     ```


### PR DESCRIPTION
I missed the documentation change after commit https://github.com/nanocurrency/nano-work-server/pull/3/commits/a4a99c4c2ce2a77446d3061a68ce39c2581301c4