### PR TITLE
Return an error when hex strings are too short

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,6 +106,7 @@ enum RpcCommand {
 enum HexJsonError {
     InvalidHex,
     TooLong,
+    TooShort
 }
 
 impl RpcService {
@@ -146,7 +147,10 @@ impl RpcService {
             .as_str()
             .and_then(|s| hex::decode(s).ok())
             .ok_or(HexJsonError::InvalidHex)?;
-        if bytes.len() > out.len() {
+        if bytes.len() < out.len() {
+            return Err(HexJsonError::TooShort)
+        }
+        else if bytes.len() > out.len() {
             return Err(HexJsonError::TooLong);
         }
         for (byte, out) in bytes.iter().rev().zip(out.iter_mut().rev()) {
@@ -166,6 +170,10 @@ impl RpcService {
                 "error": "Bad block hash",
                 "hint": "Expecting a hex string",
             }),
+            HexJsonError::TooShort => json!({
+                "error": "Bad block hash",
+                "hint": "Hash is too short (should be 32 bytes)",
+            }),
             HexJsonError::TooLong => json!({
                 "error": "Bad block hash",
                 "hint": "Hash is too long (should be 32 bytes)",
@@ -184,6 +192,10 @@ impl RpcService {
             HexJsonError::InvalidHex => json!({
                 "error": "Failed to deserialize JSON",
                 "hint": "Expecting a hex string for work",
+            }),
+            HexJsonError::TooShort => json!({
+                "error": "Bad block hash",
+                "hint": "Work is too short (should be 8 bytes)",
             }),
             HexJsonError::TooLong => json!({
                 "error": "Failed to deserialize JSON",


### PR DESCRIPTION
Right now this is valid (both hash and work can be empty or, in general, a size lower than expected):
```json
{"action": "work_validate", "hash":"", "work":""}
```
It just does left zero padding on whatever is missing. This fails to follow the behavior of the node which will error out in these cases, so I added a check for that.

While useful for testing (being able to quickly generate random work without a valid hash), it had no use in production as far as I can see.