### PR TITLE
Update for node release v21

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ![Build](https://github.com/nanocurrency/nano-work-server/workflows/Build/badge.svg)
 
-This project is a dedicated work server for [the Nano cryptocurrency](https://nano.org/).
+This project is a dedicated work server for [the Nano cryptocurrency](https://nano.org/). See the [documentation](https://docs.nano.org/integration-guides/work-generation/) for details on work generation and the current network difficulty.
 
-It supports the `work_generate`, `work_cancel`, and `work_validate` commands from the Nano RPC.
+**nano-work-server** supports the `work_generate`, `work_cancel`, and `work_validate` commands from the Nano RPC.
 For details on these commands, see [the Nano RPC documentation](https://docs.nano.org/commands/rpc-protocol/).
 
 To see available command line options, run `nano-work-server --help`.
@@ -47,6 +47,8 @@ cd target/release
 
 ## Using
 
+_Note_ difficulty values may be outdated in these examples.
+
 - `work_generate` example:
 
     ```json
@@ -87,7 +89,6 @@ cd target/release
         "difficulty": "ffffffd21c3933f4",
         "multiplier": "1.3946469"
     }
-
     ```
 
 - `work_cancel` example:

--- a/src/main.rs
+++ b/src/main.rs
@@ -374,21 +374,17 @@ impl RpcService {
                 let (valid_receive, _) = work_valid(root, work, LIVE_RECEIVE_DIFFICULTY);
                 Box::new(future::ok((
                     StatusCode::Ok,
-                    match difficulty {
-                        Some(_) => json!({
-                            "valid": if valid { "1" } else { "0" },
+                    {
+                        let mut result = json!({
                             "valid_all": if valid_all { "1" } else { "0" },
                             "valid_receive": if valid_receive { "1" } else { "0" },
                             "difficulty": format!("{:x}", result_difficulty),
                             "multiplier": format!("{}", self.to_multiplier(result_difficulty)),
-                        }),
-                        None => json!({
-                            // "valid" removed to break loudly, see https://github.com/nanocurrency/nano-node/pull/2689
-                            "valid_all": if valid_all { "1" } else { "0" },
-                            "valid_receive": if valid_receive { "1" } else { "0" },
-                            "difficulty": format!("{:x}", result_difficulty),
-                            "multiplier": format!("{}", self.to_multiplier(result_difficulty)),
-                        })
+                        });
+                        if difficulty.is_some() {
+                            result.as_object_mut().unwrap().insert(String::from("valid"), json!(if valid {"1"} else {"0"}));
+                        }
+                        result
                     },
                 )))
             }


### PR DESCRIPTION
- Removed `beta` flag no one uses. Maintaining this is too difficult with the difficulty changes. Program will error if that flag is given. This is not necessary for distributed work requests as those include the absolute difficulty
- Update threshold to 8x current
- Add lower receive threshold
- Follow changes to work_validate