### PR TITLE
fix(readme): Revise work_validate example response

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ _Note_ difficulty values may be outdated in these examples.
 
     ```json
     {
-        "valid": "1",
+        "valid_all": "1",
+        "valid_receive": "1",
         "difficulty": "ffffffd21c3933f4",
         "multiplier": "1.3946469"
     }


### PR DESCRIPTION
In the nano node version V21, the `valid` is no longer included in the response, and uses the new response fields `valid_all` and `valid_receive` to replace it.

More information: https://docs.nano.org/commands/rpc-protocol/#work_validate