### PR TITLE
Benchmark action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -505,7 +505,7 @@ dependencies = [
 
 [[package]]
 name = "nano-work-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "blake2",
  "byteorder",

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ _Note_ difficulty values may be outdated in these examples.
 
 ## Benchmarking
 
-Exame request:
+Example request:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -121,3 +121,29 @@ _Note_ difficulty values may be outdated in these examples.
     {
     }
     ```
+
+## Benchmarking
+
+Exame request:
+
+```json
+{
+    "action": "benchmark",
+    "count": "10"
+}
+```
+
+_Note_ use a sufficiently high count as work generation is a random process.
+
+Example response:
+
+```json
+{
+    "average": "481",
+    "count": "10",
+    "difficulty": "fffffff800000000",
+    "duration": "4813",
+    "hint": "Times in milliseconds",
+    "multiplier": "1"
+}
+```

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,11 +1,11 @@
 use ocl;
-use ocl::ProQue;
-use ocl::Result;
+use ocl::builders::DeviceSpecifier;
+use ocl::builders::ProgramBuilder;
+use ocl::flags::MemFlags;
 use ocl::Buffer;
 use ocl::Platform;
-use ocl::flags::MemFlags;
-use ocl::builders::ProgramBuilder;
-use ocl::builders::DeviceSpecifier;
+use ocl::ProQue;
+use ocl::Result;
 
 use byteorder::{ByteOrder, LittleEndian};
 
@@ -17,7 +17,12 @@ pub struct Gpu {
 }
 
 impl Gpu {
-    pub fn new(platform_idx: usize, device_idx: usize, threads: usize, local_work_size: Option<usize>) -> Result<Gpu> {
+    pub fn new(
+        platform_idx: usize,
+        device_idx: usize,
+        threads: usize,
+        local_work_size: Option<usize>,
+    ) -> Result<Gpu> {
         let mut prog_bldr = ProgramBuilder::new();
         prog_bldr.src(include_str!("work.cl"));
         let platforms = Platform::list();
@@ -29,7 +34,8 @@ impl Gpu {
                 "Platform index {} too large (max {})",
                 platform_idx,
                 platforms.len() - 1
-            ).into());
+            )
+            .into());
         }
         let pro_que = ProQue::builder()
             .prog_bldr(prog_bldr)


### PR DESCRIPTION
Use with `{"action":"benchmark", "count":"N"}` and optionals for difficulty and multiplier.

Example response when setting an optional multiplier "2" :
```json
{
    "average": "6084",
    "count": "2",
    "difficulty": "fffffffc00000000",
    "duration": "12168",
    "hint": "Times in milliseconds",
    "multiplier": "2"
}
```

Also formatted the rust files, IDE decided to be fancy.