### PR TITLE
Expose stats on queue size

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,22 @@ Example response:
     "multiplier": "1"
 }
 ```
+
+## Status
+
+Example request:
+
+```json
+{
+    "action": "status"
+}
+```
+
+Example response:
+
+```json
+{
+    "generating": "1",
+    "queue_size": "3"
+}
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -480,8 +480,8 @@ impl RpcService {
                 let state = self.work_state.0.lock();
                 let queue_size = state.future_work.len();
                 let resp = json!({
-                    "queue_size": queue_size,
-                    "generating": !state.task_complete.load(atomic::Ordering::Relaxed),
+                    "queue_size": format!("{}", queue_size),
+                    "generating": if state.task_complete.load(atomic::Ordering::Relaxed) {"0"} else {"1"},
                 });
                 let _ = println!("Status {}", resp);
                 Box::new(Box::new(future::ok((StatusCode::Ok, resp))))

--- a/src/main.rs
+++ b/src/main.rs
@@ -481,6 +481,7 @@ impl RpcService {
                 let queue_size = state.future_work.len();
                 let resp = json!({
                     "queue_size": queue_size,
+                    "generating": !state.task_complete.load(atomic::Ordering::Relaxed),
                 });
                 let _ = println!("Status {}", resp);
                 Box::new(Box::new(future::ok((StatusCode::Ok, resp))))
@@ -617,6 +618,7 @@ fn main() {
     let work_state = Arc::new((Mutex::new(WorkState::default()), Condvar::new()));
     {
         let mut state = work_state.0.lock();
+        state.task_complete.store(true, atomic::Ordering::Relaxed);
         state.random_mode = random_mode;
     }
     let mut worker_handles = Vec::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,11 +327,11 @@ impl RpcService {
                 Self::parse_multiplier_json(&json)?,
                 Self::parse_count_json(&json)?,
             )),
-            Some(action) if action == "work_server_status" => Ok(RpcCommand::Status()),
+            Some(action) if action == "status" => Ok(RpcCommand::Status()),
             Some(_) => {
                 return Err(json!({
                     "error": "Unknown command",
-                    "hint": "Supported commands: work_generate, work_cancel, work_validate, work_server_status"
+                    "hint": "Supported commands: work_generate, work_cancel, work_validate, benchmark, status"
                 }))
             }
         }


### PR DESCRIPTION
For diagnostics purposes, it is helpful to have statistics on the queue size, to expose the current queue size.

A new status command is implemented:

```shell
curl -d '{"action":"status"}' localhost:7076
```

```json
{
    "queue_size": 2
}
```

Fixes #24 